### PR TITLE
add mozilla readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "immer": "^5.0.0",
     "mark.js": "^8.11.1",
     "mithril": "^2.0.4",
+    "readability": "file:../readability",
     "rss-parser": "^3.7.3",
     "semver-compare": "^1.0.0",
     "typedoc-default-themes": "^0.6.1"

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -90,6 +90,7 @@ import * as Native from "@src/lib/native"
 import * as TTS from "@src/lib/text_to_speech"
 import * as excmd_parser from "@src/parsers/exmode"
 import * as escape from "@src/lib/escape"
+import { Readability } from "readability"
 
 /**
  * This is used to drive some excmd handling in `composite`.
@@ -1472,6 +1473,18 @@ export async function credits() {
     tabopen(creditspage)
 }
 
+/** Opens the current page in Firefox's reader mode.
+ * You currently cannot use Tridactyl while in reader mode.
+ */
+//#background
+export async function reader() {
+    document.body.prepend("HELLO WORLD")
+    console.log("goodbye moon")
+    console.log(Readability)
+    console.log(CSS)
+    return 1
+}
+
 /**
  * Cover the current page in an overlay to prevent clicking on links with the mouse to force yourself to use hint mode. Get rid of it by reloading the page.
  *
@@ -1787,21 +1800,6 @@ export async function zoom(level = 0, rel = "false") {
         if (level < 0.3) level = 0.3
     }
     browser.tabs.setZoom(level)
-}
-
-/** Opens the current page in Firefox's reader mode.
- * You currently cannot use Tridactyl while in reader mode.
- */
-//#background
-export async function reader() {
-    if (await firefoxVersionAtLeast(58)) {
-        const aTab = await activeTab()
-        if (aTab.isArticle) {
-            browser.tabs.toggleReaderMode()
-        } // else {
-        //  // once a statusbar exists an error can be displayed there
-        // }
-    }
 }
 
 /** @hidden **/

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,6 +6389,9 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+"readability@file:../readability":
+  version "0.2.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"


### PR DESCRIPTION
line 1481 works as expected
line 1482 returns "unavailable"
line 1483 works as expected

This might be due to the sharedContext/vm stuff here: https://github.com/mozilla/readability/blob/master/index.js. Not sure how to fix.